### PR TITLE
Revert namespace change

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -1,8 +1,5 @@
 <?php declare(strict_types = 1);
 
-namespace Ninjify\Nunjuck;
-
-use Closure;
 use Mockista\Mock;
 use Mockista\MockBuilder;
 use Mockista\MockInterface;


### PR DESCRIPTION
I accidentally changed behavior with addition of namespace (`test() -> Ninjify\Nunjuck\test()`)
@f3l1x Could you please re-tag 0.2.1?